### PR TITLE
Updating EC list following 2025 election

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -4,24 +4,25 @@
 
 The members of the current Executive Committee are (with term dates):
 
-* **Maria Baldini** – Fermilab – Accelerator R&D ('24-'25) 
-* **Karri DiPetrillo** – University of Chicago – ATLAS ('24-'25) 
-* **Steve Goldfarb** – University of Melbourne – ATLAS ('23-'24) 
-* **Julia Gonski** – SLAC – ATLAS ('24-'25) 
-* **Matt LeBlanc** – Brown – CMS ('24-'25) 
-* **Claire Lee** – Fermilab – CMS ('23-'24) 
-* **Lawrence Lee** – University of Tennessee – CMS ('24-'25) 
-* **Elise Le Boulicaut Ennis** – Yale University – ATLAS ('23-'24) 
-* **Kiley Kennedy** – Princeton – CMS ('23-'24) 
-* **Kaori Maeshima** – Fermilab – CMS ('23-'24) 
-* **Harvey Newman** – Caltech – CMS  ('22-'23) 
-* **Jannicke Pearkes** – CU Boulder – CMS ('23-'24) 
-* **David Saltzberg** – UCLA – CMS ('23-'24) 
-* **John Stupak** – University of Oklahoma – ATLAS ('23-'24) 
-* **Anyes Taffard** – UC Irvine – ATLAS ('22-'23) 
-* **Deepa Thomas** – University of Texas, Austin – ALICE ('24-'25) 
-* **Caterina Vernieri** – SLAC – ATLAS ('24-'25) 
-* **Michael K. Wilkinson** – Cincinnati – LHCb ('24-'25) 
+* **Saptaparna Bhattacharya**, SMU, CMS (2025-2026)
+* **Laura Bruce**, Harvard, ATLAS (2025-2026)
+* **Philip Chang**, University of Florida, CMS (2025-2026)
+* **Steve Goldfarb**, Michigan, ATLAS (2025-2026)
+* **Kiley Kennedy**, Princeton, CMS (2025-2026)
+* **Elise Le Boulicaut Ennis**, Yale, ATLAS (2025-2026)
+* **David Saltzberg** (Treasurer), UCLA, CMS (2025-2026)
+* **John Stupak**, Oklahoma, ATLAS (2025-2026)
+* **Emily Thompson**, LBL, ATLAS (2025-2026)
+
+* **Maria Baldini**, Fermilab, Accelerator R&D (2024-2025)
+* **Karri DiPetrillo**, Chicago, ATLAS (2024-2025)
+* **Julia Gonski** (APS Liaison; Sec’y), SLAC, ATLAS (2024-2025) 
+* **Matt LeBlanc**, Brown, CMS (2024-2025)
+* **Lawrence Lee**, Tennessee, CMS (2024-2025)
+* **Harvey Newman** (Chair), Caltech, CMS (2024-2025)
+* **Deepa Thomas**, Texas Austin, ALICE (2024-2025) 
+* **Caterina Vernieri** (Co-Chair), SLAC, ATLAS (2024-2025)
+* **Michael K. Wilkinson**, Cincinnati, LHCb (2024-2025)
 
 Members with observer status:
 


### PR DESCRIPTION
Updating the EC list following this year's election.

Also changed the format a little for some easier updating in the future.