### PR TITLE
Update redirect to point to full DC packet

### DIFF
--- a/content/dc2025.md
+++ b/content/dc2025.md
@@ -1,1 +1,1 @@
-<meta http-equiv="refresh" content="0; url=https://uslua.org/dcmaterials/DRAFT_USPP_Small_Packet_040125.pdf" />
+<meta http-equiv="refresh" content="0; url=https://drive.google.com/file/d/1xc7CnFIs_0qCODvWy2NymUZoLD4bZyXS" />


### PR DESCRIPTION
The full packet is now ready, so I have updated the redirect.

It is an 86MB PDF, so I felt it was better to redirect to gdrive rather than adding that massive file to the GitHub repository.