### PR TITLE
update dc2026 redirect url

### DIFF
--- a/content/dc2026.md
+++ b/content/dc2026.md
@@ -1,1 +1,1 @@
-<meta http-equiv="refresh" content="0; url=https://drive.google.com/file/d/1xc7CnFIs_0qCODvWy2NymUZoLD4bZyXS" />
+<meta http-equiv="refresh" content="0; url=https://drive.google.com/file/d/1HpXfLAjI2iAjkNOyhABefTemP3wT5K9i" />


### PR DESCRIPTION
The final 2026 packet is now available, so I have updated the redirect URL accordingly.